### PR TITLE
Set password when creating user via API

### DIFF
--- a/liquidcore/config/serializers.py
+++ b/liquidcore/config/serializers.py
@@ -51,6 +51,14 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
         fields = ('url', 'username', 'first_name',
                   'last_name', 'is_admin', 'is_active')
 
+class UserCreateSerializer(UserSerializer):
+    password = serializers.CharField(validators=[valid_password],
+        required=False)
+
+    class Meta:
+        model = UserSerializer.Meta.model
+        fields = UserSerializer.Meta.fields + ('password',)
+
 class UserActiveSerializer(serializers.Serializer):
     is_active = serializers.BooleanField()
 

--- a/liquidcore/config/views.py
+++ b/liquidcore/config/views.py
@@ -26,6 +26,16 @@ class UserViewSet(viewsets.ModelViewSet):
     lookup_field = 'username'
     lookup_value_regex = serializers.USERNAME_URL_REGEX
 
+    def create(self, request):
+        serializer = serializers.UserCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        User.objects.create_user(**serializer.validated_data)
+
+        clean_data = serializer.validated_data
+        clean_data.pop('password', None)
+        return Response(clean_data, status=status.HTTP_201_CREATED)
+
     # @list_route creates an endpoint that doesn't contain the pk.
     # We don't return a list, but that's not a problem.
     @list_route(

--- a/testsuite/test_config_users.py
+++ b/testsuite/test_config_users.py
@@ -28,12 +28,14 @@ def test_create_users(client, admin_user):
 
     create = client.post('/api/users/', data={
         "username": "mike",
+        "password": "1234567890",
         "is_admin": False,
         "first_name": "Mike",
         "last_name": "Tyson",
         "is_active": True,
     })
     assert create.status_code == 201
+    assert 'password' not in create.json()
 
     user_list = client.get("/api/users/")
     assert set(u['username'] for u in user_list.json()) == set(["admin", "mike"])
@@ -45,6 +47,9 @@ def test_create_users(client, admin_user):
     assert get_mike.json()['first_name'] == "Mike"
     assert get_mike.json()['last_name'] == "Tyson"
     assert get_mike.json()['is_active'] == True
+
+    mike = User.objects.get(username='mike')
+    assert mike.check_password('1234567890')
 
 def test_admins_cant_change_username(client, admin_user):
     assert client.login(username='admin', password='q')


### PR DESCRIPTION
This patch adds a `password` field to the `POST /api/users/` (create user) endpoint. The field is currently optional, so that @m-nic has time to update the JS code. I think, in the long run, the field should be required.
