### PR TITLE
disable changing the domain name after it's set up

### DIFF
--- a/liquidcore/config/views.py
+++ b/liquidcore/config/views.py
@@ -158,9 +158,8 @@ class NetworkDomain(NetworkSettingAPIView):
     setting_name = "domain"
     serializer_class = serializers.NetworkDomainSerializer
 
-    @staticmethod
-    def to_db(value):
-        return value["domain"]
+    def put(self, request, format=None):
+        return Response("network.domain is read-only", status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
     @staticmethod
     def from_db(value):


### PR DESCRIPTION
closes https://github.com/liquidinvestigations/liquidinvestigations/issues/211
build at https://jenkins.liquiddemo.org/blue/organizations/jenkins/liquidinvestigations%2Fsetup/detail/forbid-domain-change/2/pipeline