### PR TITLE
Don't use lockfile when checking for `is_broken`

### DIFF
--- a/liquidcore/config/agent.py
+++ b/liquidcore/config/agent.py
@@ -114,11 +114,15 @@ def enumerate_jobs(var):
 
 def is_broken(var):
     state_db = State(var)
-    with lock(var / 'agent.lock'):
-        if state_db.load().get('job'):
+    job_id = state_db.load().get('job')
+    if job_id:
+        job = Job(job_id, var)
+        with job.pid_file.open(encoding='latin1') as f:
+            pid = int(f.read())
+        if not psutil.pid_exists(pid):
             return True
-        else:
-            return False
+
+    return False
 
 
 


### PR DESCRIPTION
Because a worker will hold the lock until it's finished, which will
block our `status()` function. This patch looks for the pidfile and
checks if the process is still alive.

Granted, there are a couple of race conditions, which result in an
exception or false positive for `is_broken` (not false negative though).
The UI will retry the API call, so it should be fine.

Fixes https://github.com/liquidinvestigations/core/issues/30