### PR TITLE
Serve the /welcome form without having initialize.sh run beforehand

### DIFF
--- a/liquidcore/welcome/urls.py
+++ b/liquidcore/welcome/urls.py
@@ -2,5 +2,6 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
+    url(r'^done/$', views.welcome_done),
     url(r'^$', views.welcome),
 ]

--- a/liquidcore/welcome/views.py
+++ b/liquidcore/welcome/views.py
@@ -21,14 +21,14 @@ def welcome(request):
         domain.data = request.POST['domain']
         domain.save()
 
+        reconfigure_system()
+
         User.objects.create_user(
             username=request.POST['admin-username'],
             password=request.POST['admin-password'],
             is_staff=True,
             is_superuser=True
         )
-
-        reconfigure_system()
 
         WELCOME_DONE.touch()
 

--- a/liquidcore/welcome/views.py
+++ b/liquidcore/welcome/views.py
@@ -1,17 +1,38 @@
 import json
 from pathlib import Path
 from django.shortcuts import render
-from django.contrib.auth.models import User
 from django.http import HttpResponseRedirect
 from ..config.models import Setting
 from ..config.system import reconfigure_system
+from django.http import JsonResponse
 
 WELCOME_DONE = Path('/var/lib/liquid/core/welcome_done')
+WELCOME_STARTED = Path('/var/lib/liquid/core/welcome_started')
 USERS_FILE = Path('/var/lib/liquid/core/users.json')
 
 
 def should_welcome():
     return not WELCOME_DONE.is_file()
+
+
+def has_welcome_started():
+    return WELCOME_STARTED.is_file()
+
+
+def get_welcome_domain():
+    with WELCOME_STARTED.open('r') as f:
+        return f.read()
+
+
+def welcome_done(request):
+    data = {
+        "done": not should_welcome(),
+        "started": has_welcome_started(),
+    }
+    if data['started']:
+        data['domain'] = get_welcome_domain()
+
+    return JsonResponse(data)
 
 
 def welcome(request):
@@ -33,8 +54,15 @@ def welcome(request):
 
         reconfigure_system()
 
-        return render(request, 'welcome-applying.html', {
-            'url': 'http://' + request.POST['domain'],
-        })
+        with WELCOME_STARTED.open('w') as f:
+            f.write(request.POST['domain'])
 
-    return render(request, 'welcome.html')
+        return HttpResponseRedirect('/welcome/')
+
+    elif request.method == 'GET':
+        if has_welcome_started():
+            return render(request, 'welcome-applying.html', {
+                'url': 'http://' + get_welcome_domain(),
+            })
+        else:
+            return render(request, 'welcome.html')

--- a/liquidcore/welcome/views.py
+++ b/liquidcore/welcome/views.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from django.shortcuts import render
 from django.contrib.auth.models import User
@@ -6,6 +7,7 @@ from ..config.models import Setting
 from ..config.system import reconfigure_system
 
 WELCOME_DONE = Path('/var/lib/liquid/core/welcome_done')
+USERS_FILE = Path('/var/lib/liquid/core/users.json')
 
 
 def should_welcome():
@@ -21,14 +23,15 @@ def welcome(request):
         domain.data = request.POST['domain']
         domain.save()
 
-        reconfigure_system()
-
-        User.objects.create_user(
+        user_info = dict(
             username=request.POST['admin-username'],
             password=request.POST['admin-password'],
-            is_staff=True,
-            is_superuser=True
+            is_admin=True,
         )
+        with USERS_FILE.open('w') as f:
+            json.dump(user_info, f)
+
+        reconfigure_system()
 
         WELCOME_DONE.touch()
 

--- a/liquidcore/welcome/views.py
+++ b/liquidcore/welcome/views.py
@@ -50,7 +50,7 @@ def welcome(request):
             is_admin=True,
         )
         with USERS_FILE.open('w') as f:
-            json.dump(user_info, f)
+            json.dump([user_info], f)
 
         reconfigure_system()
 

--- a/liquidcore/welcome/views.py
+++ b/liquidcore/welcome/views.py
@@ -33,8 +33,6 @@ def welcome(request):
 
         reconfigure_system()
 
-        WELCOME_DONE.touch()
-
         return render(request, 'welcome-applying.html', {
             'url': 'http://' + request.POST['domain'],
         })


### PR DESCRIPTION
This does a set of things:
- uses several more files to flag state, like `welcome_done` and `welcome_started`
- makes the `/welcome` endpoint refreshable (so the browsers don't ask for resubmitting the POST data)
- doesn't create the users right after starting the initialize job, but lets initialize do it
  