### PR TITLE
Use an env var to select django configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ WORKDIR /app
 ADD requirements.txt ./
 RUN pip install -r requirements.txt
 
+ENV DJANGO_SETTINGS_MODULE liquidcore.site.settings.docker_local
 COPY . .
-COPY liquidcore/site/settings/docker_local.py liquidcore/site/settings/local.py
 
 VOLUME /app/var
 ENV PYTHONUNBUFFERED 1

--- a/liquidcore/site/settings/__init__.py
+++ b/liquidcore/site/settings/__init__.py
@@ -1,2 +1,0 @@
-from .common import *
-from .local import *

--- a/liquidcore/site/settings/docker_local.py
+++ b/liquidcore/site/settings/docker_local.py
@@ -1,5 +1,7 @@
 import re
 
+from .common import *
+
 DEBUG = True
 SECRET_KEY = 'foo'
 ALLOWED_HOSTS = ['*']


### PR DESCRIPTION
This is needed to mount a local code repository over the docker image and still have it working.