### PR TITLE
Auth staff only

### DIFF
--- a/liquidcore/home/auth.py
+++ b/liquidcore/home/auth.py
@@ -1,0 +1,13 @@
+from django.conf import settings
+from django.contrib.auth.backends import ModelBackend
+
+staff_only = settings.AUTH_STAFF_ONLY
+
+
+class AuthBackend(ModelBackend):
+
+    def user_can_authenticate(self, user):
+        if staff_only and not user.is_staff:
+            return False
+
+        return super().user_can_authenticate(user)

--- a/liquidcore/home/auth.py
+++ b/liquidcore/home/auth.py
@@ -1,5 +1,9 @@
+import json
+import base64
 from django.conf import settings
 from django.contrib.auth.backends import ModelBackend
+from django.contrib.sessions.models import Session
+from oauth2_provider.models import RefreshToken, AccessToken
 
 staff_only = settings.AUTH_STAFF_ONLY
 
@@ -11,3 +15,35 @@ class AuthBackend(ModelBackend):
             return False
 
         return super().user_can_authenticate(user)
+
+
+def kill_sessions(user=None):
+    """
+    Delete oauth2 access and refresh tokens, for `user` if specified, or for
+    everybody if `user == None`.
+    """
+
+    if user:
+        # for the user
+        access_tokens = user.oauth2_provider_accesstoken.all()
+        refresh_tokens = user.oauth2_provider_refreshtoken.all()
+    else:
+        # for everybody
+        access_tokens = AccessToken.objects.all()
+        refresh_tokens = RefreshToken.objects.all()
+
+    access_tokens.delete()
+    refresh_tokens.delete()
+
+    # delete all Django sessions
+    if user:
+        # for the user
+        for session in Session.objects.all().iterator():
+            session_data = base64.b64decode(session.session_data)
+            session_json = session_data.split(b':', 1)[1]
+            user_id = json.loads(session_json).get('_auth_user_id')
+            if user_id and int(user_id) == user.id:
+                session.delete()
+    else:
+        # for everybody
+        Session.objects.all().delete()

--- a/liquidcore/home/management/commands/killsessions.py
+++ b/liquidcore/home/management/commands/killsessions.py
@@ -1,5 +1,4 @@
 from django.core.management.base import BaseCommand
-from django.contrib.auth import authenticate
 from ...auth import kill_sessions
 
 

--- a/liquidcore/home/management/commands/killsessions.py
+++ b/liquidcore/home/management/commands/killsessions.py
@@ -1,0 +1,11 @@
+from django.core.management.base import BaseCommand
+from django.contrib.auth import authenticate
+from ...auth import kill_sessions
+
+
+class Command(BaseCommand):
+
+    help = "Log out all users"
+
+    def handle(self, **options):
+        kill_sessions()

--- a/liquidcore/home/signals.py
+++ b/liquidcore/home/signals.py
@@ -1,19 +1,8 @@
-import json
-import base64
 from django.dispatch import receiver
 from django.contrib.auth.signals import user_logged_out
-from django.contrib.sessions.models import Session
+from .auth import kill_sessions
 
 
 @receiver(user_logged_out)
-def kill_sessions(user, **kwargs):
-    # delete oauth2 access and refresh tokens for the user
-    user.oauth2_provider_accesstoken.all().delete()
-    user.oauth2_provider_refreshtoken.all().delete()
-
-    # delete all Django sessions for the user
-    for session in Session.objects.all().iterator():
-        session_json = base64.b64decode(session.session_data).split(b':', 1)[1]
-        user_id = json.loads(session_json).get('_auth_user_id')
-        if user_id and int(user_id) == user.id:
-            session.delete()
+def kill_user_sessions(user, **kwargs):
+    kill_sessions(user=user)

--- a/liquidcore/site/settings.py
+++ b/liquidcore/site/settings.py
@@ -48,6 +48,8 @@ MIDDLEWARE = [
     'whitenoise.middleware.WhiteNoiseMiddleware',
 ]
 
+AUTH_STAFF_ONLY = bool_env(os.environ.get('AUTH_STAFF_ONLY'))
+
 if LIQUID_2FA:
     INSTALLED_APPS += [
         'liquidcore.twofactor',
@@ -67,7 +69,7 @@ if LIQUID_2FA:
 
 AUTHENTICATION_BACKENDS = [
     'oauth2_provider.backends.OAuth2Backend',
-    'django.contrib.auth.backends.ModelBackend'
+    'liquidcore.home.auth.AuthBackend',
 ]
 
 ROOT_URLCONF = 'liquidcore.site.urls'


### PR DESCRIPTION
Only permit logins from users with `is_staff == True`. To log out all users, run `./manage.py killsessions`.