### PR TITLE
Grant admin privileges to a user

### DIFF
--- a/liquidcore/twofactor/management/commands/makeadmin.py
+++ b/liquidcore/twofactor/management/commands/makeadmin.py
@@ -1,0 +1,17 @@
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import User
+
+
+class Command(BaseCommand):
+
+    help = "Grant admin privileges to this user"
+
+    def add_arguments(self, parser):
+        parser.add_argument('username')
+
+    def handle(self, username, **options):
+        user = User.objects.get(username=username)
+        user.is_superuser = True
+        user.is_staff = True
+        user.save()
+        print(f"{user} is now admin")


### PR DESCRIPTION
For the times when you want to make a superuser from the command-line, run `invite`, and then realize that somehow you need to make the new user into an admin.
