### PR TITLE
[add] OIDC_RSA_PRIVATE_KEY

### DIFF
--- a/liquidcore/site/settings.py
+++ b/liquidcore/site/settings.py
@@ -162,6 +162,7 @@ OAUTH2_PROVIDER = {
     'REFRESH_TOKEN_GRACE_PERIOD_SECONDS': 120,  # recommended from docs
     "OIDC_ENABLED": True,
     "OIDC_ISS_ENDPOINT": LIQUID_URL,
+    "OIDC_RSA_PRIVATE_KEY" : os.environ.get('OIDC_RSA_PRIVATE_KEY'),
     "OAUTH2_VALIDATOR_CLASS": "liquidcore.home.oauth2_validator.CustomOAuth2Validator",
     'SCOPES': {
         "openid": "OpenID Connect scope",


### PR DESCRIPTION
 as per documented in 
https://django-oauth-toolkit.readthedocs.io/en/latest/settings.html#oidc-rsa-private-key